### PR TITLE
Handle nil HTTP response in diagnostics

### DIFF
--- a/garage/error.go
+++ b/garage/error.go
@@ -17,11 +17,14 @@ func createDiagnositc(err error, http *http.Response) diag.Diagnostic {
 		Summary:  err.Error(),
 	}
 
-	apiError := new(garageAPIError)
+	if http != nil && http.Body != nil {
+		defer http.Body.Close()
 
-	decodeErr := json.NewDecoder(http.Body).Decode(apiError)
-	if decodeErr == nil {
-		diagnostic.Detail = apiError.Message
+		apiError := new(garageAPIError)
+
+		if decodeErr := json.NewDecoder(http.Body).Decode(apiError); decodeErr == nil {
+			diagnostic.Detail = apiError.Message
+		}
 	}
 
 	return diagnostic


### PR DESCRIPTION
## Summary
- guard diagnostic creation against nil HTTP responses and close response bodies

## Testing
- `GIT_TERMINAL_PROMPT=0 go test ./... -run TestNonExistent -count=1`
- `pre-commit run --files garage/error.go` *(fails: pre-commit not installed and package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688ef9e0d054832a8f795d023e73d95d